### PR TITLE
Remove events from two endpoints and adjust a third one

### DIFF
--- a/endpoints/deliverables/get.js
+++ b/endpoints/deliverables/get.js
@@ -64,7 +64,7 @@ module.exports = async (req, res) => {
 
     checkIfExist(deliverable);
     const response = getJSONApiResponseFromRecord(db, 'Deliverables', deliverable, {
-      includeModels: ['DeliverableTemplates', 'Events', 'Users']
+      includeModels: ['DeliverableTemplates', 'Users']
     });
     res.send(response);
   } catch (err) {

--- a/endpoints/eventTemplates/list.js
+++ b/endpoints/eventTemplates/list.js
@@ -5,43 +5,7 @@ const { getDB } = require('../../db/db.js');
 module.exports = async (req, res) => {
   try {
     const db = getDB();
-    const filter = req.query.filter;
 
-    const userInfo = req.userInfo;
-    // console.log(userInfo);
-
-    const { roles } = req.userInfo;
-    const isAdmin = roles.find(role => role === 'ADMIN') !== undefined;
-
-    let demoFilter = {};
-    const eventInclude = [];
-    if (!isAdmin && !(filter && 'asCorrector' in filter)) {
-      demoFilter = {
-        DemonstratorId: userInfo.userId
-      };
-      eventInclude.push({
-        where: demoFilter,
-        model: db.Events,
-        include: [
-          {
-            model: db.StudentRegistrations
-          },
-          {
-            model: db.Users,
-            as: 'Demonstrator'
-          },
-          {
-            model: db.Deliverables
-          },
-          {
-            model: db.EventTemplates
-          },
-          {
-            model: db.ExerciseSheets
-          }
-        ]
-      });
-    }
     const records = await db.EventTemplates.findAll(
       {
         include: [
@@ -56,7 +20,6 @@ module.exports = async (req, res) => {
           {
             model: db.DeliverableTemplates
           },
-          ...eventInclude
         ],
         order: ['seqNumber']
       }

--- a/endpoints/exerciseTypes/get.js
+++ b/endpoints/exerciseTypes/get.js
@@ -8,16 +8,16 @@ module.exports = async (req, res) => {
     const reqIdNum = parseInt(reqId, 10);
     const { roles } = req.userInfo;
 
-    // only ADMIN DEMONSTRATOR CORRECTOR
-    if (!roles.includes('ADMIN') && !roles.includes('DEMONSTRATOR') && !roles.includes('CORRECTOR')) {
-      res.status(403).send(genErrorObj('Unathorized'));
-      return;
+    let include = []
+    // only ADMIN DEMONSTRATOR CORRECTOR should get included data
+    if (roles.includes('ADMIN') || roles.includes('DEMONSTRATOR') || !roles.includes('CORRECTOR')) {
+      include.push({ all: true })
     }
 
     const db = getDB();
     const record = await db.ExerciseTypes.findById(
       reqIdNum,
-      { include: [{ all: true }] }
+      { include: include }
     );
     checkIfExist(record);
     const response = getJSONApiResponseFromRecord(db, 'ExerciseTypes', record, {


### PR DESCRIPTION
- EventTemplates/list: we don't need to include all this data in the results as we don't use it and it makes the application slow.
- Deliverables/get: we already have the data in the relationships so this is duplicate here
- ExerciseTypes/get: students should get the details here. I saw an error locally for this even on the master branch.